### PR TITLE
Backend tests are only 1 fail

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -1,13 +1,13 @@
 {
   "development": {
-    "username": "tinymurky",
+    "username": "root",
     "password": "password",
     "database": "ac_twitter_workspace",
     "host": "127.0.0.1",
     "dialect": "mysql"
   },
   "test": {
-    "username": "tinymurky",
+    "username": "root",
     "password": "password",
     "database": "ac_twitter_workspace_test",
     "host": "127.0.0.1",

--- a/middlewares/auth.js
+++ b/middlewares/auth.js
@@ -43,7 +43,7 @@ const adminLocalAuth = (req, res, next) => {
 
       if (user.role !== 'admin') {
         req.flash('error_messages', '只有管理員可以訪問此區域')
-        return res.redirect('back')
+        return res.redirect('/')
       }
 
       // activate passport.sequrlizeUser


### PR DESCRIPTION
經修改後，測試檔只有 1 個錯誤。

推特顯示部分：

```
3 passing (393ms)
  1 failing

  1) # Admin::Tweet request
       go to admin user page
         if admin user log in
           cant go to /tweets page:
     Error: expected "Location" of "/admin/tweets", got "/admin/signin"
      at Test._assertHeader (node_modules\supertest\lib\test.js:249:12)
      at Test._assertFunction (node_modules\supertest\lib\test.js:283:11)
      at Test.assert (node_modules\supertest\lib\test.js:173:18)
      at Server.localAssert (node_modules\supertest\lib\test.js:131:12)
      at Object.onceWrapper (node:events:628:28)
      at Server.emit (node:events:514:28)
      at emitCloseNT (node:net:2273:8)
      at process.processTicksAndRejections (node:internal/process/task_queues:81:21)
```